### PR TITLE
Removes hook causing sass to compile whenever a lein command was run

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,6 @@
    {"sassc"
     {:file-pattern #"\.(scss|sass)$" :paths ["resources/scss"]}}
 
-  :hooks [leiningen.sassc]
   :clean-targets ^{:protect false}
   [:target-path [:cljsbuild :builds :app :compiler :output-dir] [:cljsbuild :builds :app :compiler :output-to]]
   :figwheel


### PR DESCRIPTION
Closes [#49](https://github.com/codefordenver/CWBN/issues/49)