### PR TITLE
Fix 89

### DIFF
--- a/src/cljs/cwbn/components/search_bar.cljs
+++ b/src/cljs/cwbn/components/search_bar.cljs
@@ -60,6 +60,7 @@
      :on-change #(reset! typeahead-on-change-value %)
      :change-on-blur? change-on-blur?
      :rigid? rigid?
+     :debounce-delay 500
      :status @status]))
 
 (defn component []

--- a/src/cljs/cwbn/components/search_bar.cljs
+++ b/src/cljs/cwbn/components/search_bar.cljs
@@ -5,7 +5,7 @@
 (declare test-data)
 
 (def typeahead-on-change-value (reagent/atom nil))
-(def change-on-blur? (reagent/atom false))
+(def change-on-blur? (reagent/atom true))
 (def status (reagent/atom nil))
 (def rigid? (reagent/atom true))
 
@@ -60,7 +60,6 @@
      :on-change #(reset! typeahead-on-change-value %)
      :change-on-blur? change-on-blur?
      :rigid? rigid?
-     :debounce-delay 500
      :status @status]))
 
 (defn component []


### PR DESCRIPTION
Set change-on-blur to true so that the typeahead only autocompletes when the user selects a suggestion. This prevents the mouseover bug from occuring, but may not be the behavior we want. 