### PR TITLE
Fixing loading of categories at the initial page

### DIFF
--- a/src/cljs/cwbn/pages/category.cljs
+++ b/src/cljs/cwbn/pages/category.cljs
@@ -21,21 +21,20 @@
                                       (:categories org)))
                               @all-orgs)
         orgs (sort-by :name filtered-orgs)]
-    (fn []
-      [:div
-       [search-bar/component]
-       [:div.category-page
-        [:div {:class "category-header flex items-center"}
-         [:img {:class "category-icon"
-                :src   (str "img/category-icons/" category-img)}]
-         [:div {:class "category-services flex flex-column"}
-          [:h1 {:class "f3 b ttc"} category-name]
-          [:div
-           (for [service category-services]
-             ^{:key (gensym "service-")}
-             [:span {:class "service-link fw6"}
-              [:a {:href category-route} service]])]]]
-        [sorted-list/component orgs]]])))
+    [:div
+     [search-bar/component]
+     [:div.category-page
+      [:div {:class "category-header flex items-center"}
+       [:img {:class "category-icon"
+              :src   (str "img/category-icons/" category-img)}]
+       [:div {:class "category-services flex flex-column"}
+        [:h1 {:class "f3 b ttc"} category-name]
+        [:div
+         (for [service category-services]
+           ^{:key (gensym "service-")}
+           [:span {:class "service-link fw6"}
+            [:a {:href category-route} service]])]]]
+      [sorted-list/component orgs]]]))
 
 (def services-by-category
   {:business-development  ["Pre-Idea",


### PR DESCRIPTION
If the user tried to load categories as the fist page, then the page would load
before the organizations were fetched from the server and no organizations were
displayed. This was because the categories page returned an anonymous function
that captured the value of the orgs as a clojure and did not update when the
original data change. We could fix this two ways, capture the ratom in the
clojure or remove the anonymous function. I choose the
second option because it was the simplest but we could change it to the first if
there is areason to do so.

The bug can be rei-created by hard-reloading the webpage after going to a
catagory.