### PR TITLE
Adding names to routes

### DIFF
--- a/src/cljs/cwbn/pages/category.cljs
+++ b/src/cljs/cwbn/pages/category.cljs
@@ -13,13 +13,14 @@
         next-query (if active?
                      (remove #{service} selected-services)
                      (conj selected-services service))
-        query-string (if-not (empty? next-query)
-                       (str "?selected-services=" (s/join "+" next-query))
-                       "")
+        query-params (when-not (empty? next-query)
+                       {:selected-services (s/join "+" next-query)})
         class (if (or active? (empty? selected-services))
                 "service-selected"
-                "service-not-selected")]
-    [:a {:class class :href (str "/#/category/" category query-string)} service]))
+                "service-not-selected")
+        url (routes/category-path {:category category
+                                   :query-params query-params})]
+  [:a {:class class :href url} service]))
 
 (defn category-page []
   (let [all-orgs (rf/subscribe [:Organizations])
@@ -58,7 +59,7 @@
             [sub-category-link category-route service selected-services]])
          (when-not (empty? selected-services)
            [:span {:class "service-link fw6 reset"}
-            [:a {:class "service-selected" :href (str "/#/category/" category-route)} "Reset"]])]]]
+            [:a {:class "service-selected" :href (routes/category-path {:category category-route})} "Reset"]])]]]
       [sorted-list/component orgs]]]))
 
 (def services-by-category

--- a/src/cljs/cwbn/routes.cljs
+++ b/src/cljs/cwbn/routes.cljs
@@ -21,22 +21,22 @@
 (defn app-routes []
   (secretary/set-config! :prefix "#")
 
-  (defroute "/" []
+  (defroute home-path "/" []
             (rf/dispatch [:set-active-page :home]))
 
-  (defroute "/about" []
+  (defroute about-path "/about" []
             (rf/dispatch [:set-active-page :about]))
 
-  (defroute "/contact" []
+  (defroute contact-path "/contact" []
             (rf/dispatch [:set-active-page :contact]))
 
-  (defroute "/category/:category" {:as params}
+  (defroute category-path "/category/:category" {:as params}
             (rf/dispatch [:set-catogory-page-as-active params]))
 
-  (defroute "/search/:search" {:as params}
+  (defroute search-path "/search/:search" {:as params}
             (rf/dispatch [:set-active-page :search params]))
 
-  (defroute "*" []
+  (defroute not-found-path "*" []
             (rf/dispatch [:set-active-page :not-found]))
 
   ;; --------------------


### PR DESCRIPTION
Naming routes adds a function in the cwbn/routes ns which you can use to
get the default path or build a path based on rules for the route.